### PR TITLE
Ignore uses of Method or MethodByName not marked with AttrReflectMethod

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,6 @@ func main() {
 	}
 	flag.Parse()
 
-	reflectMethods["reflect.Value.MethodByName"] = true
-	reflectMethods["reflect.Value.Method"] = true
 	seen := map[string]bool{}
 	first := true
 	ul := []string{}


### PR DESCRIPTION
Fixes https://github.com/aarzilli/whydeadcode/issues/2.

Since https://go-review.googlesource.com/c/go/+/522436, uses of `Method` or `MethodByName` with a constant argument don't disable full dead code elimination, and in that case they are not marked with the `ReflectMethod` attribute.

This PR stops considering every use of those methods as a `ReflectMethod`, now only uses which are marked with the attribute will be kept.

Tested locally and seems to fix the false positive issue.
