### PR TITLE
Add flag to fail on non-empty findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,28 @@
 
 Displays why deadcode elimination was partially disabled by the Go linker.
 
-The Go linker will disable most deadcode elimination if it finds reachable calls to `reflect.Value.MethodByName` or `reflect.Value.Method`. This is done because, using these two methods it is possible to dynamically call any public method in the application. 
+The Go linker will disable most deadcode elimination if it finds reachable calls to `reflect.Value.MethodByName` or `reflect.Value.Method`. This is done because, using these two methods it is possible to dynamically call any public method in the application.
 Whydeadcode uses the call graph produced by the linker to display why `reflect.Value.MethodByName` or `reflect.Value.Method` are reachable. Use it like this:
 
 ```
-	go build -ldflags=-dumpdep your/package |& whydeadcode
+go build -ldflags=-dumpdep your/package |& whydeadcode
 ```
 
 Needs Go 1.21 or later.
 
 Because of how `-dumpdep` works only the first result output by whydeadcode is real. Because of how `-dumpdep` works anything beyond the first result can be a false positive (i.e. things that look like they will affect deadcode elimination but won't if the first result is taken care of) and it can also have false negatives (i.e. things that will continue to keep deadcode elimination disabled if the first result is taken care of).
+
+# USAGE
+
+```console
+$ whydeadcode -h
+Usage of whydeadcode:
+        go build -ldflags=-dumpdep ... |& whydeadcode
+  -fail
+        Fail on non-empty findings
+  -ignore-unrecognized-input
+        Ignore unrecognized input
+```
 
 # TALK
 


### PR DESCRIPTION
Following up on #4 this change adds a flag to exit with non-zero status code in case of any findings.

This is useful for CI/scripting as currently user has to test for empty output.