### PR TITLE
Do not ignore reflect types on path

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,10 +72,6 @@ bufScanLoop:
 
 func enum(path []string, seen map[string]bool) bool {
 	last := path[len(path)-1]
-	if last == "type:reflect.Value" || last == "type:*reflect.rtype" || last == "type:*reflect.Value" {
-		// these are almost always false positives so we skip them
-		return false
-	}
 	seen[last] = true
 	defer func() {
 		if !visitOnce(last) {


### PR DESCRIPTION
The tool considers that any symbol reachable through one of `type:reflect.Value`, `type:*reflect.rtype`, or `type:*reflect.Value` is a false positive and skips it.

While this is likely true, there are cases where the real reason the optimization is disabled is due to those types directly, so skipping means showing an incorrect first result. Also, the first symbol marked with the `<ReflectMethod>` marker is always the root cause of the optimization being disabled, so for the first symbol it should definitely not make any assumption like that.

My fix is just to remove the assumption in the code, but I could also update the code to only do so for the very first symbol, not the remaining ones.

### Example

Consider the following `-dumpdep` output [linker-out.txt](https://github.com/user-attachments/files/25152158/linker-out.txt) generated with Go 1.26rc2.

Currently `whydeadcode` shows the root cause to be the following:
```
text/template.(*state).evalField reachable from:
	 text/template.(*state).evalFieldChain
	 text/template.(*state).evalCommand
	 text/template.(*state).evalPipeline
	 text/template.(*state).walk
	 text/template.(*Template).execute
	 text/template.(*Template).Execute
	 github.com/spf13/cobra.(*Command).SetUsageTemplate.tmpl.func1
	 github.com/spf13/cobra.(*Command).SetUsageTemplate
	 type:*github.com/spf13/cobra.Command
	 github.com/DataDog/datadog-agent/cmd/trace-agent/command.makeCommands
	 main.main
	 runtime.main_main·f
	 runtime.main
	 runtime.mainPC
	 runtime.rt0_go
	 main
	 _
```

It shows that having the type `*github.com/spf13/cobra.Command` makes its `SetUsageTemplate` reachable, but only because at that point the optimization is already disabled.

The real one is the following:
```
reflect.(*rtype).Methods.func1 reachable from:
	 reflect.(*rtype).Methods
	 type:*reflect.rtype
	 fmt.(*pp).printArg
	 fmt.(*pp).doPrintln
	 fmt.Fprintln
	 github.com/DataDog/datadog-agent/cmd/internal/runcmd.displayError
	 github.com/DataDog/datadog-agent/cmd/internal/runcmd.Run
	 main.main
	 runtime.main_main·f
	 runtime.main
	 runtime.mainPC
	 runtime.rt0_go
	 main
	 _
```

The type `*reflect.rtype` makes its method `Methods` reachable due to a call to `MethodByName("Methods")` [in protobuf-go](https://github.com/protocolbuffers/protobuf-go/blob/v1.36.11/internal/descfmt/stringer.go#L265) (see the associated issue for reference https://github.com/golang/protobuf/issues/1704).