### PR TITLE
skip stdlib <ReflectMethod> functions to fix Go 1.26 false positives

### DIFF
--- a/_fixtures/stdlibonly.go
+++ b/_fixtures/stdlibonly.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// stdlibonly exercises code paths that pull in stdlib <ReflectMethod> functions
+// (e.g. fmt.Errorf -> fmt.(*pp).doPrintf -> reflect.TypeOf -> *reflect.rtype,
+// and text/template via cobra-style usage templates) without any user-code
+// reflection. whydeadcode should produce no findings for this binary.
+func main() {
+	if len(os.Args) > 1 {
+		err := errors.New(os.Args[1])
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -63,7 +63,14 @@ bufScanLoop:
 			if fields[i] == "" {
 				continue bufScanLoop
 			}
-			if strings.Contains(flags, "<ReflectMethod>") {
+			// Only track <ReflectMethod> from external (non-stdlib) packages.
+			// Stdlib functions like reflect.(*rtype).Methods.func1 or
+			// text/template.(*state).evalField carry <ReflectMethod> due to
+			// internal implementation details that users cannot avoid or fix.
+			// Reporting them produces false positives. External packages (those
+			// with a module path such as "github.com/..." or "k8s.io/...") are
+			// user-controlled and their ReflectMethod usage is actionable.
+			if strings.Contains(flags, "<ReflectMethod>") && isExternalPkg(fields[i]) {
 				reflectMethods[fields[i]] = true
 			}
 		}
@@ -135,6 +142,27 @@ func visitOnce(sym string) bool {
 		return false
 	}
 	return strings.Index(sym[:slash], ".") >= 0
+}
+
+// isExternalPkg reports whether sym belongs to a user-controlled (non-stdlib) package.
+// Stdlib package paths either have no slash with a non-"main" package name
+// (e.g., "reflect.(*rtype).Methods.func1", "fmt.Errorf"), or have a slash but
+// no dot in the first path segment (e.g., "text/template.(*state).evalField").
+// User/external packages are:
+//   - "main.*" — the user's own main package or test fixture
+//   - module paths with a dot before the first slash: "github.com/...", "k8s.io/..."
+func isExternalPkg(sym string) bool {
+	slash := strings.Index(sym, "/")
+	if slash < 0 {
+		// No slash: stdlib (e.g., "reflect", "fmt") or the "main" package.
+		// "main" is always user-controlled code.
+		dot := strings.Index(sym, ".")
+		if dot < 0 {
+			return false
+		}
+		return sym[:dot] == "main"
+	}
+	return strings.Contains(sym[:slash], ".") // dot before first slash = external module
 }
 
 func (path Path) Print() {

--- a/main_test.go
+++ b/main_test.go
@@ -34,6 +34,17 @@ func TestWhydeadcode(t *testing.T) {
 	}
 }
 
+// TestStdlibOnlyNoFindings verifies that a binary whose only <ReflectMethod>
+// functions are in the stdlib (e.g. fmt, text/template, reflect iterators
+// added in Go 1.26) produces no whydeadcode findings. These are false positives
+// that users cannot fix.
+func TestStdlibOnlyNoFindings(t *testing.T) {
+	paths, _ := Whydeadcode(buildFixture(t, "stdlibonly"))
+	if len(paths) != 0 {
+		t.Errorf("expected no findings for stdlib-only binary, got %d:\n%v", len(paths), paths)
+	}
+}
+
 func buildFixture(t *testing.T, name string) io.Reader {
 	t.Helper()
 	cmd := exec.Command("go", "build", "-o", "_debug", "-ldflags=-dumpdep", filepath.Join("_fixtures", name)+".go")


### PR DESCRIPTION
@aarzilli thanks for maintaining `whydeadcode`, we have been using it in kubernetes for a while now. Context for this PR is we ran into some issues updating kubernetes to 1.26 - https://github.com/kubernetes/kubernetes/pull/137080#issuecomment-3967559680

(full log file is here https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/137080/pull-kubernetes-verify/2026932754385473536/build-log.txt)

Go 1.26 added reflect.Type.Methods() and reflect.Value.Methods() iterator methods, whose closures carry the <ReflectMethod> linker flag. The fmt package references type:*reflect.rtype (via reflect.TypeOf in doPrintf), which causes reflect.(*rtype).Methods.func1 to be reported as reachable in any binary that calls fmt.Errorf. Similarly, text/template.(*state).evalField carries <ReflectMethod> because it calls reflect.Value.MethodByName with a non-constant argument — inherent to how templates resolve field/method names.

Neither of these is actionable by the user: the reflection lives in the stdlib, not in user-controlled code. Reporting them is pure noise.

Fix: only add functions to the reflectMethods set if they belong to a user-controlled (non-stdlib) package. Stdlib packages are identified as either:
  - no slash in the symbol path and package name != "main" (e.g. "reflect.(*rtype).Methods.func1", "fmt.Errorf")
  - a slash but no dot before the first slash (e.g. "text/template.(*state).evalField", "encoding/json.Marshal")

The "main" package and all module paths (github.com/..., k8s.io/..., etc.) are treated as user code and continue to be reported.

Adds a TestStdlibOnlyNoFindings test and a stdlibonly.go fixture that exercises the fmt/reflect path without any user-controlled reflection.